### PR TITLE
Fix README installation duplicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,6 @@ PyTEA_Pi/
 - **Python:** Versión 3.7 o superior.
 - Dependencias especificadas en `requirements.txt`.
 
-## 🛠️ Instalación
-
-### Requisitos previos
-
-- Sistema operativo: Cualquier distribución basada en Linux (incluido Raspberry Pi OS).
-- Python: Versión 3.7 o superior.
-- Dependencias especificadas en requirements.txt.
-
 ### Instrucciones
 1. Clona el repositorio:
    ```bash


### PR DESCRIPTION
## Summary
- remove second installation heading and repeated prerequisite bullets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fff345e408328ae71555daabb14d3