### PR TITLE
Add basic test for root widget build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 kivy
+pytest

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+# Add repository root to path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Prevent Kivy from parsing command line arguments
+os.environ.setdefault('KIVY_NO_ARGS', '1')
+
+from src.ventana_principal import PyTEAApp, VentanaPrincipal
+
+
+def test_app_builds_root_widget(monkeypatch):
+    # Patch VentanaPrincipal.__init__ to avoid heavy Kivy initialization
+    monkeypatch.setattr(VentanaPrincipal, "__init__", lambda self, **kw: None)
+    app = PyTEAApp()
+    root = app.build()
+    assert isinstance(root, VentanaPrincipal)


### PR DESCRIPTION
## Summary
- include `pytest` in requirements
- add test verifying that `PyTEAApp` can build its root widget without errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840111019708328a4dcaf17c0d8f29c